### PR TITLE
feat: add Exa AI-powered search tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,6 +96,7 @@ Gemini Grounded Search gives you Google-quality results through the Gemini API. 
 | DuckDuckGo | Unlimited | None | Available |
 | Bing | Unlimited | None | Available |
 | Serper | 2,500 trial | `SERPER_API_KEY` | Available |
+| Exa | 1,000/month | `EXA_API_KEY` | Available |
 | Google CSE | 100/day | `GOOGLE_CSE_KEY` | Available |
 | Jina Reader | Unlimited | None | Available |
 | SearXNG | Unlimited | Self-hosted | Available |
@@ -846,6 +847,7 @@ GEMINI_API_KEY      Free — primary search + summarization (aistudio.google.com
 BRAVE_API_KEY       Brave Search (2,000 free/month)
 TAVILY_API_KEY      Tavily Search (1,000 free/month)
 SERPER_API_KEY      Serper.dev (2,500 trial queries)
+EXA_API_KEY         Exa Search (1,000 free/month, neural + content retrieval)
 GITHUB_TOKEN        For GitHub adapter
 DEVTO_API_KEY       For Dev.to adapter
 HF_TOKEN            For HuggingFace adapter

--- a/index.d.ts
+++ b/index.d.ts
@@ -6,6 +6,20 @@ declare module 'spectrawl' {
       geminiKey?: string
       'gemini-grounded'?: { apiKey?: string; model?: string }
       tavily?: { apiKey?: string; searchDepth?: string; maxResults?: number }
+      exa?: {
+        apiKey?: string
+        maxResults?: number
+        type?: 'neural' | 'fast' | 'auto' | 'deep-lite' | 'deep' | 'deep-reasoning' | 'instant'
+        category?: 'company' | 'research paper' | 'news' | 'personal site' | 'financial report' | 'people'
+        includeDomains?: string[]
+        excludeDomains?: string[]
+        startPublishedDate?: string
+        endPublishedDate?: string
+        startCrawlDate?: string
+        endCrawlDate?: string
+        userLocation?: string
+        contents?: false | Record<string, unknown>
+      }
       llm?: { provider: string; model?: string; apiKey?: string }
       sourceRanker?: {
         weights?: Record<string, number>

--- a/src/search/engines/exa.js
+++ b/src/search/engines/exa.js
@@ -1,0 +1,99 @@
+const https = require('https')
+
+/**
+ * Exa Search API — AI-native search with neural understanding and content retrieval.
+ * Returns clean, agent-ready results with highlights, full text, and summaries.
+ * Get an API key at https://dashboard.exa.ai.
+ */
+async function exaSearch(query, config = {}) {
+  const apiKey = config.apiKey || process.env.EXA_API_KEY
+  if (!apiKey) throw new Error('EXA_API_KEY required for Exa search')
+
+  const maxResults = config.maxResults || 10
+
+  const contents = buildContents(config)
+
+  const payload = {
+    query,
+    type: config.type || 'auto',
+    numResults: maxResults,
+    ...(contents && { contents }),
+    ...(config.category && { category: config.category }),
+    ...(config.includeDomains && { includeDomains: config.includeDomains }),
+    ...(config.excludeDomains && { excludeDomains: config.excludeDomains }),
+    ...(config.startPublishedDate && { startPublishedDate: config.startPublishedDate }),
+    ...(config.endPublishedDate && { endPublishedDate: config.endPublishedDate }),
+    ...(config.startCrawlDate && { startCrawlDate: config.startCrawlDate }),
+    ...(config.endCrawlDate && { endCrawlDate: config.endCrawlDate }),
+    ...(config.userLocation && { userLocation: config.userLocation })
+  }
+
+  const data = await post('https://api.exa.ai/search', JSON.stringify(payload), apiKey)
+
+  if (!Array.isArray(data.results)) {
+    throw new Error(`Exa search failed: ${JSON.stringify(data).slice(0, 200)}`)
+  }
+
+  return data.results.map(r => ({
+    url: r.url,
+    title: r.title || '',
+    snippet: extractSnippet(r),
+    engine: 'exa'
+  }))
+}
+
+function buildContents(config) {
+  if (config.contents === false) return null
+  if (config.contents && typeof config.contents === 'object') return config.contents
+
+  // Default: highlights + a capped text window — matches the "agent-ready" shape
+  // used by the rest of the cascade (snippet-sized content, not full pages).
+  return {
+    highlights: true,
+    text: { maxCharacters: 1000 }
+  }
+}
+
+function extractSnippet(result) {
+  if (Array.isArray(result.highlights) && result.highlights.length > 0) {
+    return result.highlights.join(' ')
+  }
+  if (typeof result.summary === 'string' && result.summary) {
+    return result.summary
+  }
+  if (typeof result.text === 'string' && result.text) {
+    return result.text.slice(0, 500)
+  }
+  return ''
+}
+
+function post(url, body, apiKey) {
+  return new Promise((resolve, reject) => {
+    const urlObj = new URL(url)
+    const opts = {
+      hostname: urlObj.hostname,
+      path: urlObj.pathname,
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'Content-Length': Buffer.byteLength(body),
+        'x-api-key': apiKey,
+        'x-exa-integration': 'spectrawl'
+      }
+    }
+    const req = https.request(opts, res => {
+      let data = ''
+      res.on('data', c => data += c)
+      res.on('end', () => {
+        try { resolve(JSON.parse(data)) }
+        catch (e) { reject(new Error(`Invalid Exa response: ${data.slice(0, 200)}`)) }
+      })
+    })
+    req.on('error', reject)
+    req.setTimeout(10000, () => { req.destroy(); reject(new Error('Exa search timeout')) })
+    req.write(body)
+    req.end()
+  })
+}
+
+module.exports = { exaSearch }

--- a/src/search/index.js
+++ b/src/search/index.js
@@ -7,6 +7,7 @@ const { jinaSearch } = require('./engines/jina')
 const { bingSearch } = require('./engines/bing')
 const { geminiGroundedSearch } = require('./engines/gemini-grounded')
 const { tavilySearch } = require('./engines/tavily')
+const { exaSearch } = require('./engines/exa')
 const { scrapeUrls } = require('./scraper')
 const { Summarizer } = require('./summarizer')
 const { Reranker } = require('./reranker')
@@ -23,7 +24,8 @@ const ENGINES = {
   'gemini-grounded': geminiGroundedSearch,
   gemini: geminiGroundedSearch,
   bing: bingSearch,
-  tavily: tavilySearch
+  tavily: tavilySearch,
+  exa: exaSearch
 }
 
 class SearchEngine {

--- a/test/exa.test.js
+++ b/test/exa.test.js
@@ -1,0 +1,172 @@
+const { describe, it, beforeEach, afterEach } = require('node:test')
+const assert = require('node:assert/strict')
+const https = require('https')
+const { EventEmitter } = require('events')
+
+const { exaSearch } = require('../src/search/engines/exa')
+
+/**
+ * Stubs https.request so tests run offline and can assert on the
+ * request shape Exa actually receives.
+ */
+function stubHttps({ responseBody, statusCode = 200, capture = {} }) {
+  const original = https.request
+  https.request = (opts, cb) => {
+    capture.opts = opts
+    const req = new EventEmitter()
+    req.setTimeout = () => {}
+    req.destroy = () => {}
+    req.write = body => { capture.body = body }
+    req.end = () => {
+      const res = new EventEmitter()
+      res.statusCode = statusCode
+      cb(res)
+      res.emit('data', Buffer.from(typeof responseBody === 'string' ? responseBody : JSON.stringify(responseBody)))
+      res.emit('end')
+    }
+    return req
+  }
+  return () => { https.request = original }
+}
+
+describe('Exa Search', () => {
+  let restore
+  const originalKey = process.env.EXA_API_KEY
+
+  beforeEach(() => { process.env.EXA_API_KEY = 'test-key' })
+
+  afterEach(() => {
+    if (restore) restore()
+    if (originalKey === undefined) delete process.env.EXA_API_KEY
+    else process.env.EXA_API_KEY = originalKey
+  })
+
+  it('throws when EXA_API_KEY is not set', async () => {
+    delete process.env.EXA_API_KEY
+    await assert.rejects(() => exaSearch('test'), /EXA_API_KEY required/)
+  })
+
+  it('maps API response into the cascade result shape', async () => {
+    const capture = {}
+    restore = stubHttps({
+      capture,
+      responseBody: {
+        results: [
+          {
+            url: 'https://example.com/a',
+            title: 'Example A',
+            highlights: ['match one', 'match two'],
+            text: 'full text body'
+          }
+        ]
+      }
+    })
+
+    const results = await exaSearch('agent frameworks')
+    assert.equal(results.length, 1)
+    assert.deepEqual(results[0], {
+      url: 'https://example.com/a',
+      title: 'Example A',
+      snippet: 'match one match two',
+      engine: 'exa'
+    })
+  })
+
+  it('sends x-api-key and x-exa-integration headers', async () => {
+    const capture = {}
+    restore = stubHttps({ capture, responseBody: { results: [] } })
+
+    await exaSearch('q')
+    assert.equal(capture.opts.headers['x-api-key'], 'test-key')
+    assert.equal(capture.opts.headers['x-exa-integration'], 'spectrawl')
+  })
+
+  it('defaults type=auto and includes contents with highlights + text', async () => {
+    const capture = {}
+    restore = stubHttps({ capture, responseBody: { results: [] } })
+
+    await exaSearch('q')
+    const sent = JSON.parse(capture.body)
+    assert.equal(sent.type, 'auto')
+    assert.equal(sent.query, 'q')
+    assert.equal(sent.numResults, 10)
+    assert.equal(sent.contents.highlights, true)
+    assert.deepEqual(sent.contents.text, { maxCharacters: 1000 })
+  })
+
+  it('forwards filters (category, domains, dates, userLocation)', async () => {
+    const capture = {}
+    restore = stubHttps({ capture, responseBody: { results: [] } })
+
+    await exaSearch('q', {
+      type: 'neural',
+      maxResults: 3,
+      category: 'research paper',
+      includeDomains: ['arxiv.org'],
+      excludeDomains: ['reddit.com'],
+      startPublishedDate: '2024-01-01T00:00:00.000Z',
+      endPublishedDate: '2024-12-31T00:00:00.000Z',
+      userLocation: 'US'
+    })
+
+    const sent = JSON.parse(capture.body)
+    assert.equal(sent.type, 'neural')
+    assert.equal(sent.numResults, 3)
+    assert.equal(sent.category, 'research paper')
+    assert.deepEqual(sent.includeDomains, ['arxiv.org'])
+    assert.deepEqual(sent.excludeDomains, ['reddit.com'])
+    assert.equal(sent.startPublishedDate, '2024-01-01T00:00:00.000Z')
+    assert.equal(sent.endPublishedDate, '2024-12-31T00:00:00.000Z')
+    assert.equal(sent.userLocation, 'US')
+  })
+
+  it('allows disabling contents retrieval', async () => {
+    const capture = {}
+    restore = stubHttps({ capture, responseBody: { results: [] } })
+
+    await exaSearch('q', { contents: false })
+    const sent = JSON.parse(capture.body)
+    assert.equal(sent.contents, undefined)
+  })
+
+  it('allows custom contents object override', async () => {
+    const capture = {}
+    restore = stubHttps({ capture, responseBody: { results: [] } })
+
+    await exaSearch('q', { contents: { summary: { query: 'what is this?' } } })
+    const sent = JSON.parse(capture.body)
+    assert.deepEqual(sent.contents, { summary: { query: 'what is this?' } })
+  })
+
+  it('falls back through snippet sources: highlights -> summary -> text', async () => {
+    const capture = {}
+    restore = stubHttps({
+      capture,
+      responseBody: {
+        results: [
+          { url: 'https://a', title: 'A', highlights: ['h1'] },
+          { url: 'https://b', title: 'B', summary: 'summary-only' },
+          { url: 'https://c', title: 'C', text: 'raw text body that should be truncated' },
+          { url: 'https://d', title: 'D' }
+        ]
+      }
+    })
+
+    const results = await exaSearch('q')
+    assert.equal(results[0].snippet, 'h1')
+    assert.equal(results[1].snippet, 'summary-only')
+    assert.equal(results[2].snippet, 'raw text body that should be truncated')
+    assert.equal(results[3].snippet, '')
+  })
+
+  it('throws a descriptive error when the API returns a non-results payload', async () => {
+    restore = stubHttps({ responseBody: { error: 'invalid api key' } })
+    await assert.rejects(() => exaSearch('q'), /Exa search failed/)
+  })
+
+  it('is registered in the cascade engine registry', () => {
+    const { SearchEngine } = require('../src/search')
+    const engine = new SearchEngine({ cascade: ['exa'] })
+    assert.ok(engine, 'SearchEngine with exa cascade should construct without throwing')
+  })
+})


### PR DESCRIPTION
## Summary

Adds [Exa](https://exa.ai) as an additional search provider in the cascade, alongside the existing nine engines. Exa is an AI-native search engine that returns clean, agent-ready results with built-in content retrieval (highlights, text, summaries), neural search, and rich filtering (category, domains, dates, user location).

- New `src/search/engines/exa.js` following the same `https`-based pattern as `tavily.js`, `brave.js`, and `serper.js`
- Registered under the `exa` key in the `ENGINES` cascade registry
- Reads `EXA_API_KEY` from env (or `config.exa.apiKey`)
- Defaults to `type: 'auto'` with `contents: { highlights: true, text: { maxCharacters: 1000 } }` so results land in the same snippet-sized shape the cascade already expects — configurable per-call
- Forwards `category`, `includeDomains` / `excludeDomains`, `startPublishedDate` / `endPublishedDate`, `startCrawlDate` / `endCrawlDate`, and `userLocation`
- Snippet extraction cascades through `highlights` → `summary` → `text` so any combination of `contents` options produces a usable result
- TypeScript typings added for `config.search.exa`
- README updated: engines table row and env var reference

## Usage

```js
const { Spectrawl } = require('spectrawl')

const web = new Spectrawl({
  search: {
    cascade: ['gemini-grounded', 'exa', 'tavily'],
    exa: { type: 'neural', category: 'research paper' }
  }
})

const result = await web.deepSearch('transformer architectures for long context')
console.log(result.sources)
```

Set `EXA_API_KEY` in your environment (1,000 free searches/month, get a key at https://dashboard.exa.ai).

## Files changed

- `src/search/engines/exa.js` — new engine
- `src/search/index.js` — register `exa` in the cascade
- `index.d.ts` — add `exa` config typings
- `README.md` — engines table + env var
- `test/exa.test.js` — 10 unit tests covering the engine end-to-end

## Test plan

- [x] Added unit tests for `exaSearch` covering:
  - Missing `EXA_API_KEY` → throws
  - API response → cascade result shape mapping
  - `x-api-key` and `x-exa-integration` headers on the outgoing request
  - Default request body (`type: 'auto'`, `numResults: 10`, `contents` shape)
  - Filter forwarding: `type`, `maxResults`, `category`, `includeDomains`, `excludeDomains`, `startPublishedDate`, `endPublishedDate`, `userLocation`
  - `contents: false` disables the contents object
  - Custom `contents` object overrides the default
  - Snippet fallback: `highlights` → `summary` → `text` → empty string
  - Non-`results` payload → descriptive error
  - Registry integration via `new SearchEngine({ cascade: ['exa'] })`
- [x] `node --test test/exa.test.js` — 10 / 10 pass
- [x] `node --test test/exa.test.js test/search.test.js test/config.test.js` — 18 / 18 pass (no regressions in existing search tests)
- [ ] Live end-to-end run against `api.exa.ai` (requires an `EXA_API_KEY`; not run in this environment)